### PR TITLE
Update Mac Wireshark plugins path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Based on the awesome [dysentery](https://github.com/Deep-Symmetry/dysentery) pro
 Copy all `.lua` files to:
 
 - (Windows)      `%APPDATA%\Wireshark\plugins\`
-- (Linux, Mac)   `$HOME/.wireshark/plugins`
+- (Linux)        `$HOME/.wireshark/plugins`
+- (Mac)          `$HOME/.config/wireshark/plugins`
 
 
 ## Screenshots

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Copy all `.lua` files to:
 
 - (Windows)      `%APPDATA%\Wireshark\plugins\`
 - (Linux)        `$HOME/.wireshark/plugins`
-- (Mac)          `$HOME/.config/wireshark/plugins`
+- (Mac)          `$HOME/.config/wireshark/plugins` (you may need to create the `plugins` folder).
+                  If the `wireshark` directory doesn't exist in `.config`, try `$HOME/.wireshark/plugins` instead —
+                  both paths may work depending on your Wireshark version.
 
 
 ## Screenshots


### PR DESCRIPTION
Hi,

Thank you for the amazing plugin! I was able to find more information about the packets coming from the OPUS-QUAD with the plugin!

For me on Wireshark 4.4.5 and on an macOS Apple Silicon device, the path was `$HOME/.config/wireshark/plugins` for me. See https://stackoverflow.com/questions/10230632/how-to-port-a-wireshark-lua-dissector-script-to-mac-osx

Not sure if Linux is the same as well, so I just made a separate bullet point!